### PR TITLE
Fix reference to hll_create

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There are two types of functions, aggregation and scalar.
 `merge(<hll: HLL>)` -> HLL
 
 ### Scalar
-`create_hll(<element:VARCHAR>, <bits: BIGINT>)` -> HLL
+`hll_create(<element:VARCHAR>, <bits: BIGINT>)` -> HLL
 
 `cardinality(<hll: HLL>)` -> BIGINT
 


### PR DESCRIPTION
It's registered as hll_create here: https://github.com/vitillo/presto-hyperloglog/blob/master/src/main/java/com/mozilla/presto/hyperloglog/HyperLogLogScalarFunctions.java#L43

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitillo/presto-hyperloglog/2)

<!-- Reviewable:end -->
