### PR TITLE
Update plugin for presto-0.157.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.152.3</version>
+        <version>0.157.1</version>
     </parent>
 
     <artifactId>presto-hyperloglog</artifactId>

--- a/src/test/java/com/mozilla/presto/hyperloglog/TestHyperLogLogQueries.java
+++ b/src/test/java/com/mozilla/presto/hyperloglog/TestHyperLogLogQueries.java
@@ -15,7 +15,6 @@
 package com.mozilla.presto.hyperloglog;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
@@ -66,8 +65,7 @@ public class TestHyperLogLogQueries
                 .build();
 
         LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);
-        InMemoryNodeManager nodeManager = localQueryRunner.getNodeManager();
-        localQueryRunner.createCatalog("tpch", new TpchConnectorFactory(nodeManager, 1), ImmutableMap.<String, String>of());
+        localQueryRunner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.<String, String>of());
 
         HyperLogLogPlugin plugin = new HyperLogLogPlugin();
         for (Type type : plugin.getTypes()) {


### PR DESCRIPTION
This currently fails the tests with an unclear error.

```
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 19.152 sec <<< FAILURE! - in com.mozilla.presto.hyperloglog.TestHyperLogLogQueries
testHyperLogLogMerge(com.mozilla.presto.hyperloglog.TestHyperLogLogQueries)  Time elapsed: 0.169 sec  <<< FAILURE!
java.lang.AssertionError: Execution of 'actual' query failed: select cardinality(merge(hll_create(v, 10))) from (values ('foo'), ('bar'), ('foo')) as t(v)
	at com.mozilla.presto.hyperloglog.TestHyperLogLogQueries.testHyperLogLogMerge(TestHyperLogLogQueries.java:42)
Caused by: java.lang.NullPointerException
	at com.mozilla.presto.hyperloglog.TestHyperLogLogQueries.testHyperLogLogMerge(TestHyperLogLogQueries.java:42)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitillo/presto-hyperloglog/5)
<!-- Reviewable:end -->
